### PR TITLE
SwiftUI Preview Extension

### DIFF
--- a/WeatherMood.xcodeproj/project.pbxproj
+++ b/WeatherMood.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8719C56626ACF83900397112 /* UIViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719C56526ACF83900397112 /* UIViewController+Preview.swift */; };
 		874FD72C26AA9E7F00F8EBC1 /* Viewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874FD72B26AA9E7F00F8EBC1 /* Viewable.swift */; };
 		878BDBCA26A9A5C900D6F5A1 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878BDBC926A9A5C900D6F5A1 /* BaseViewController.swift */; };
 		878BDBD026A9B54400D6F5A1 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878BDBCF26A9B54400D6F5A1 /* Coordinator.swift */; };
@@ -71,6 +72,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8719C56526ACF83900397112 /* UIViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Preview.swift"; sourceTree = "<group>"; };
 		874FD72B26AA9E7F00F8EBC1 /* Viewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Viewable.swift; sourceTree = "<group>"; };
 		878BDBC926A9A5C900D6F5A1 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		878BDBCF26A9B54400D6F5A1 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 		DB1A873F26A815D100E34E43 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				8719C56526ACF83900397112 /* UIViewController+Preview.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 			files = (
 				874FD72C26AA9E7F00F8EBC1 /* Viewable.swift in Sources */,
 				878BDBEA26A9BFF500D6F5A1 /* DiaryContainerViewController.swift in Sources */,
+				8719C56626ACF83900397112 /* UIViewController+Preview.swift in Sources */,
 				878BDBD426A9B69000D6F5A1 /* MainViewController.swift in Sources */,
 				878BDBF726A9C2B400D6F5A1 /* DiaryListViewModel.swift in Sources */,
 				878BDBFB26A9C39000D6F5A1 /* ConfigurationViewModel.swift in Sources */,

--- a/WeatherMood.xcodeproj/project.pbxproj
+++ b/WeatherMood.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8719C56626ACF83900397112 /* UIViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719C56526ACF83900397112 /* UIViewController+Preview.swift */; };
+		8719C56826ACF86400397112 /* UIView+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719C56726ACF86400397112 /* UIView+Preview.swift */; };
 		874FD72C26AA9E7F00F8EBC1 /* Viewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874FD72B26AA9E7F00F8EBC1 /* Viewable.swift */; };
 		878BDBCA26A9A5C900D6F5A1 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878BDBC926A9A5C900D6F5A1 /* BaseViewController.swift */; };
 		878BDBD026A9B54400D6F5A1 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878BDBCF26A9B54400D6F5A1 /* Coordinator.swift */; };
@@ -73,6 +74,7 @@
 
 /* Begin PBXFileReference section */
 		8719C56526ACF83900397112 /* UIViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Preview.swift"; sourceTree = "<group>"; };
+		8719C56726ACF86400397112 /* UIView+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Preview.swift"; sourceTree = "<group>"; };
 		874FD72B26AA9E7F00F8EBC1 /* Viewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Viewable.swift; sourceTree = "<group>"; };
 		878BDBC926A9A5C900D6F5A1 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		878BDBCF26A9B54400D6F5A1 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 			isa = PBXGroup;
 			children = (
 				8719C56526ACF83900397112 /* UIViewController+Preview.swift */,
+				8719C56726ACF86400397112 /* UIView+Preview.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 				8719C56626ACF83900397112 /* UIViewController+Preview.swift in Sources */,
 				878BDBD426A9B69000D6F5A1 /* MainViewController.swift in Sources */,
 				878BDBF726A9C2B400D6F5A1 /* DiaryListViewModel.swift in Sources */,
+				8719C56826ACF86400397112 /* UIView+Preview.swift in Sources */,
 				878BDBFB26A9C39000D6F5A1 /* ConfigurationViewModel.swift in Sources */,
 				878BDBCA26A9A5C900D6F5A1 /* BaseViewController.swift in Sources */,
 				878BDBD226A9B5A200D6F5A1 /* MainCoordinator.swift in Sources */,

--- a/WeatherMood/Extension/UIView+Preview.swift
+++ b/WeatherMood/Extension/UIView+Preview.swift
@@ -1,0 +1,30 @@
+//
+//  UIView+Preview.swift
+//  WeatherMood
+//
+//  Created by 이지원 on 2021/07/25.
+//  source: https://dev.to/gualtierofr/preview-uikit-views-in-xcode-3543
+
+import UIKit
+
+#if DEBUG
+import SwiftUI
+
+private struct Preview: UIViewRepresentable {
+    typealias UIViewType = UIView
+    let view: UIView
+
+    func makeUIView(context: Context) -> UIView {
+        view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+    }
+}
+
+extension UIView {
+    func toPreview() -> some View {
+        Preview(view: self)
+    }
+}
+#endif

--- a/WeatherMood/Extension/UIView+Preview.swift
+++ b/WeatherMood/Extension/UIView+Preview.swift
@@ -12,13 +12,13 @@ import SwiftUI
 
 private struct Preview: UIViewRepresentable {
     typealias UIViewType = UIView
-    let view: UIView
+    let view: UIViewType
 
-    func makeUIView(context: Context) -> UIView {
+    func makeUIView(context: Context) -> UIViewType {
         view
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIView(_ uiView: UIViewType, context: Context) {
     }
 }
 

--- a/WeatherMood/Extension/UIViewController+Preview.swift
+++ b/WeatherMood/Extension/UIViewController+Preview.swift
@@ -12,13 +12,13 @@ import SwiftUI
 
 private struct Preview: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIViewController
-    let viewController: UIViewController
+    let viewController: UIViewControllerType
 
-    func makeUIViewController(context: Context) -> UIViewController {
+    func makeUIViewController(context: Context) -> UIViewControllerType {
         viewController
     }
 
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
     }
 }
 

--- a/WeatherMood/Extension/UIViewController+Preview.swift
+++ b/WeatherMood/Extension/UIViewController+Preview.swift
@@ -1,0 +1,30 @@
+//
+//  UIViewController+Preview.swift
+//  WeatherMood
+//
+//  Created by 이지원 on 2021/07/25.
+//  source: https://fluffy.es/xcode-previews-uikit/
+
+import UIKit
+
+#if DEBUG
+import SwiftUI
+
+private struct Preview: UIViewControllerRepresentable {
+    typealias UIViewControllerType = UIViewController
+    let viewController: UIViewController
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        viewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}
+
+extension UIViewController {
+    func toPreview() -> some View {
+        Preview(viewController: self)
+    }
+}
+#endif


### PR DESCRIPTION
## 개요

SwiftUI Preview Extension 추가

## 작업 사항

- `UIView+Preview`
- `UIViewController+Preview`
- 원본 코드는 13버전 이상만 동작하게 명시하는 부분이 있는데, 저희는 프로젝트 버전이 13.0이라서 지웠습니다.

실제로 실행 할 때는 다음의 코드가 필요합니다. 저는 스니펫으로 만들어뒀어요.

```Swift
#if DEBUG
import SwiftUI

struct BaseViewControllerPreview: PreviewProvider {
    static var previews: some View {
        BaseViewController().toPreview()
    }
}
#endif
```

관련된 단축키는
  - resume → `command` + `option` + `p`
  - canvas open/close → `command` + `option` + `enter`

### Linked Issue

Close #14 
